### PR TITLE
fix: missing "return" on some transaction services

### DIFF
--- a/erede/service/CancelTransactionService.py
+++ b/erede/service/CancelTransactionService.py
@@ -16,4 +16,4 @@ class CancelTransactionService(TransactionService):
         return "{}/{}/refunds".format(super().get_uri(), self.transaction.tid)
 
     def execute(self):
-        self.send_request(TransactionService.POST, self.transaction.to_json())
+        return self.send_request(TransactionService.POST, self.transaction.to_json())

--- a/erede/service/CaptureTransactionService.py
+++ b/erede/service/CaptureTransactionService.py
@@ -16,4 +16,4 @@ class CaptureTransactionService(TransactionService):
         return "{}/{}".format(super().get_uri(), self.transaction.tid)
 
     def execute(self):
-        self.send_request(TransactionService.PUT, self.transaction.to_json())
+        return self.send_request(TransactionService.PUT, self.transaction.to_json())

--- a/erede/service/GetTransactionService.py
+++ b/erede/service/GetTransactionService.py
@@ -22,4 +22,4 @@ class GetTransactionService(TransactionService):
         return "{}/{}".format(super().get_uri(), self.tid)
 
     def execute(self):
-        self.send_request(TransactionService.GET)
+        return self.send_request(TransactionService.GET)


### PR DESCRIPTION
some api calls were always return 'None' because it is missing the return in the methods